### PR TITLE
Password confirmation

### DIFF
--- a/js/settingsview.js
+++ b/js/settingsview.js
@@ -1,6 +1,6 @@
 /* global Backbone, Handlebars, OC, u2f */
 
-(function(OC, Backbone, Handlebars, $, u2f) {
+(function (OC, Backbone, Handlebars, $, u2f) {
 	'use strict';
 
 	OC.Settings = OC.Settings || {};
@@ -16,40 +16,76 @@
 		+ '	{{/unless}}'
 		+ '</div>';
 
+	/**
+	 * @class OC.Settings.TwoFactorU2F.View
+	 */
 	var View = Backbone.View.extend({
+		/**
+		 * @type {function|undefined}
+		 */
 		_template: undefined,
+
+		/**
+		 * @type {boolean}
+		 */
 		_enabled: undefined,
+
+		/**
+		 * @type {boolean}
+		 */
 		_loading: false,
-		template: function(data) {
+
+		/**
+		 * @param {object} data
+		 * @returns {string}
+		 */
+		template: function (data) {
 			if (!this._template) {
 				this._template = Handlebars.compile(TEMPLATE);
 			}
 			return this._template(data);
 		},
+
 		events: {
 			'change #u2f-enabled': '_onToggleEnabled'
 		},
-		initialize: function() {
+
+		/**
+		 * @returns {undefined}
+		 */
+		initialize: function () {
 			this._load();
 		},
-		render: function() {
+
+		/**
+		 * @returns {undefined}
+		 */
+		render: function () {
 			this.$el.html(this.template({
 				enabled: this._enabled,
 				loading: this._loading
 			}));
 		},
-		_load: function() {
+
+		/**
+		 * @returns {undefined}
+		 */
+		_load: function () {
 			var url = OC.generateUrl('/apps/twofactor_u2f/settings/state');
 			$.ajax(url, {
 				method: 'GET'
-			}).done(function(data) {
+			}).done(function (data) {
 				this._enabled = data.enabled;
 				this.render();
-			}.bind(this)).fail(function() {
+			}.bind(this)).fail(function () {
 				OC.Notification.showTemporary('Could not get U2F enabled/disabled state.');
 			});
 		},
-		_onToggleEnabled: function() {
+
+		/**
+		 * @returns {undefined}
+		 */
+		_onToggleEnabled: function () {
 			if (this._loading) {
 				// Ignore event
 				return;
@@ -68,43 +104,69 @@
 				this._onDisable();
 			}
 		},
-		_onRegister: function() {
+
+		/**
+		 * @returns {undefined}
+		 */
+		_onRegister: function () {
 			this._loading = true;
 			this.render();
 			console.log('start register…');
 			var url = OC.generateUrl('apps/twofactor_u2f/settings/startregister');
 			$.ajax(url, {
 				method: 'POST'
-			}).done(function(data) {
+			}).done(function (data) {
 				this.doRegister(data.req, data.sigs);
-			}.bind(this)).fail(function() {
+			}.bind(this)).fail(function () {
 				OC.Notification.showTemporary('server error while trying to add U2F device');
 				this._loading = false;
 				this.render();
 			}.bind(this));
 		},
-		_onDisable: function() {
+
+		/**
+		 * @returns {undefined}
+		 */
+		_onDisable: function () {
 			this._loading = true;
 			this.render();
 			console.log('disabling U2F…');
 			var url = OC.generateUrl('apps/twofactor_u2f/settings/disable');
 			$.ajax(url, {
 				method: 'POST'
-			}).fail(function() {
+			}).fail(function () {
 				OC.Notification.showTemporary('Could not disable U2F');
-			}.bind(this)).always(function() {
+			}.bind(this)).always(function () {
 				this._loading = false;
 				this.render();
 			}.bind(this));
 		},
-		doRegister: function(req, sigs) {
+
+		/**
+		 * @returns {Promise}
+		 */
+		_requirePasswordConfirmation: function () {
+			if (!OC.PasswordConfirmation.requiresPasswordConfirmation()) {
+				return Promise.resolve();
+			}
+			return new Promise(function (resolve) {
+				OC.PasswordConfirmation.requirePasswordConfirmation(resolve);
+			});
+		},
+
+		/**
+		 * @param {object} req
+		 * @param {object} sigs
+		 * @returns {undefined}
+		 */
+		doRegister: function (req, sigs) {
 			console.log('doRegister', req, sigs);
 			$('.utf-register-info').slideDown();
 			var pathArray = location.href.split('/');
 			var protocol = pathArray[0];
 			var host = pathArray[2];
 			var url = protocol + '//' + host;
-			u2f.register(url, [req], sigs, function(data) {
+			u2f.register(url, [req], sigs, function (data) {
 				console.log(data);
 				if (data.errorCode && data.errorCode !== 0) {
 					OC.Notification.showTemporary('U2F device registration failed (error code ' + data.errorCode + ')');
@@ -117,15 +179,20 @@
 				this.finishRegister(data);
 			}.bind(this));
 		},
-		finishRegister: function(data) {
+
+		/**
+		 * @param {object} data
+		 * @returns {undefined}
+		 */
+		finishRegister: function (data) {
 			console.log('finish register…', data);
 			var url = OC.generateUrl('apps/twofactor_u2f/settings/finishregister');
 			$.ajax(url, {
 				method: 'POST',
 				data: data
-			}).fail(function() {
+			}).fail(function () {
 				OC.Notification.showTemporary('server error while trying to complete U2F device registration');
-			}).always(function() {
+			}).always(function () {
 				$('.utf-register-info').slideUp();
 				this._loading = false;
 				this.render();

--- a/js/settingsview.js
+++ b/js/settingsview.js
@@ -142,7 +142,7 @@
 			return Promise.resolve($.ajax(url, {
 				method: 'POST'
 			})).catch(function () {
-				throw new Error('Server error while trying to add U2F device');
+				throw new Error(t('twofactor_u2f', 'Server error while trying to add U2F device'));
 			});
 		},
 
@@ -175,7 +175,7 @@
 			return Promise.resolve($.ajax(url, {
 				method: 'POST'
 			})).catch(function () {
-				throw new Error('Server error while disabling U2F');
+				throw new Error(t('twofactor_u2f', 'Server error while disabling U2F'));
 			});
 		},
 
@@ -203,13 +203,16 @@
 			var host = pathArray[2];
 			var url = protocol + '//' + host;
 
-			return new Promise(function (resolve) {
+			return new Promise(function (resolve, reject) {
 				console.log('doRegister', req, sigs);
 				u2f.register(url, [req], sigs, function (data) {
 					console.log(data);
 					if (data.errorCode && data.errorCode !== 0) {
 						$('.utf-register-info').slideUp();
-						throw new Error('U2F device registration failed (error code ' + data.errorCode + ')');
+						reject(new Error(t('twofactor_u2f', 'U2F device registration failed (error code {errorCode})', {
+							errorCode: data.errorCode
+						})));
+						return;
 					}
 					resolve(data);
 				});
@@ -228,7 +231,7 @@
 				method: 'POST',
 				data: data
 			})).catch(function () {
-				throw new Error('Server error while trying to complete U2F device registration');
+				throw new Error(t('twofactor_u2f', 'Server error while trying to complete U2F device registration'));
 			}).then(function () {
 				$('.utf-register-info').slideUp();
 			});

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -50,6 +50,7 @@ class SettingsController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @PasswordConfirmationRequired
 	 */
 	public function disable() {
 		$this->manager->disableU2F($this->userSession->getUser());
@@ -57,6 +58,7 @@ class SettingsController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @PasswordConfirmationRequired
 	 * @UseSession
 	 */
 	public function startRegister() {
@@ -65,6 +67,7 @@ class SettingsController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @PasswordConfirmationRequired
 	 *
 	 * @param string $registrationData
 	 * @param string $clientData


### PR DESCRIPTION
This PR adds password confirmation for enabling/disabling U2F two-factor like in https://github.com/nextcloud/twofactor_totp/pull/120.

Additionally, this restructures the code a bit by extensively using es6 promises to enhance the readability and make the code less error-prone (was kind of callback hell before). Error messages are translated now too.

If you do not want to wait 15mins until the password confirmation is necessary again, you can use ```nc_lastLogin = 0;``` to fake-force it 😉 