### PR TITLE
Add possibility to add multiple U2F devices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ cache:
 
 before_install:
   - php --info
+  # Download phpunit 5.7
+  - wget https://phar.phpunit.de/phpunit-5.7.phar -O phpunit
+  - chmod u+x phpunit
+
   # XDebug is only needed if we report coverage -> speeds up other builds
   - if [[ "$PHP_COVERAGE" = "FALSE" ]]; then phpenv config-rm xdebug.ini; fi
 
@@ -74,7 +78,7 @@ script:
 
   # Run PHP tests
   - cd tests
-  - phpunit --configuration phpunit.xml
+  - ../phpunit --configuration phpunit.xml
 
   # Publish PHP coverage to scrutinizer
   - if [[ "$PHP_COVERAGE" = "TRUE" ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -46,10 +46,15 @@
                 <notnull>true</notnull>
                 <length>4</length>
             </field>
+	    <field>
+                <name>name</name>
+                <type>text</type>
+                <notnull>false</notnull>
+                <length>255</length>
+            </field>
 
             <index>
                 <name>u2f_registrations_user_id</name>
-                <unique>true</unique>
                 <field>
                     <name>user_id</name>
                     <sorting>ascending</sorting>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Two Factor U2F</name>
 	<summary>U2F two-factor provider</summary>
 	<description>A two-factor provider for U2F devices</description>
-	<version>1.2.0</version>
+	<version>1.3.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorU2F</namespace>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -26,11 +26,6 @@ return [
 			'verb' => 'GET'
 		],
 		[
-			'name' => 'settings#disable',
-			'url' => '/settings/disable',
-			'verb' => 'POST'
-		],
-		[
 			'name' => 'settings#startRegister',
 			'url' => '/settings/startregister',
 			'verb' => 'POST'
@@ -38,6 +33,11 @@ return [
 		[
 			'name' => 'settings#finishRegister',
 			'url' => '/settings/finishregister',
+			'verb' => 'POST'
+		],
+		[
+			'name' => 'settings#remove',
+			'url' => '/settings/remove',
 			'verb' => 'POST'
 		],
 	]

--- a/css/style.css
+++ b/css/style.css
@@ -21,6 +21,33 @@
 }
 
 /** icons for personal page settings **/
-.nav-icon-u2f-second-factor-auth {
+.nav-icon-u2f-second-factor-auth, .icon-u2f-device {
 	background-image: url('../img/app-dark.svg?v=1');
+}
+
+.u2f-device {
+	line-height: 300%;
+	display: flex;
+}
+.u2f-device .more {
+	position: relative;
+}
+.u2f-device .more .icon-more {
+	display: inline-block;
+	width: 16px;
+	height: 16px;
+	padding-left: 20px;
+	vertical-align: middle;
+	opacity: .7;
+}
+.u2f-device .popovermenu {
+	right: -5px;
+	top: 42px;
+}
+
+.icon-u2f-device {
+	display: inline-block;
+	background-size: 100%;
+	padding: 3px;
+	margin: 3px;
 }

--- a/js/tests/spec/settingsviewSpec.js
+++ b/js/tests/spec/settingsviewSpec.js
@@ -29,31 +29,6 @@ describe('Settings view', function () {
 		});
 
 		expect(OC.Notification.showTemporary).not.toHaveBeenCalled();
-		expect(view.$el.find('#u2f-enabled').prop('checked')).toBeUndefined();
-	});
-
-	it('ticks the checkbox if u2f is enabled for the user', function (done) {
-		spyOn(OC.Notification, 'showTemporary');
-
-		var loading = view.load();
-
-		expect(jasmine.Ajax.requests.mostRecent().url).toBe('/apps/twofactor_u2f/settings/state');
-
-		jasmine.Ajax.requests.mostRecent().respondWith({
-			status: 200,
-			contentType: 'application/json',
-			responseText: JSON.stringify({
-				enabled: true
-			})
-		});
-
-		loading.then(function () {
-			expect(OC.Notification.showTemporary).not.toHaveBeenCalled();
-			expect(view.$el.find('#u2f-enabled').prop('checked')).toBe(true);
-			done();
-		}).catch(function (e) {
-			done.fail(e);
-		});
 	});
 
 	it('shows a notification if the state cannot be loaded from the server', function (done) {
@@ -79,15 +54,14 @@ describe('Settings view', function () {
 	it('asks for password confirmation when the user enables u2f', function (done) {
 		spyOn(OC.Notification, 'showTemporary');
 		spyOn(view, '_getServerState').and.returnValue(Promise.resolve({
-			enabled: false
+			devices: []
 		}));
 		spyOn(view, '_requirePasswordConfirmation').and.returnValue(Promise.reject({
 			message: 'Wrong password'
 		}));
 
 		view.load().then(function () {
-			view.$el.find('#u2f-enabled').prop('checked', true);
-			view._onToggleEnabled().then(function () {
+			view._onAddU2FDevice().then(function () {
 				expect(OC.Notification.showTemporary).toHaveBeenCalledWith('Wrong password');
 				done();
 			}).catch(function (e) {
@@ -101,9 +75,9 @@ describe('Settings view', function () {
 	it('lets the user register a new device', function (done) {
 		spyOn(OC.Notification, 'showTemporary');
 		spyOn(view, '_getServerState').and.returnValue(Promise.resolve({
-			enabled: false
+			devices: []
 		}));
-		spyOn(view, '_registerU2fDevice').and.returnValue(Promise.resolve());
+		spyOn(view, '_registerU2fDevice').and.returnValue(Promise.resolve({}));
 		spyOn(view, '_requirePasswordConfirmation').and.returnValue(Promise.resolve());
 		jasmine.Ajax.stubRequest('/apps/twofactor_u2f/settings/startregister').andReturn({
 			contentType: 'application/json',
@@ -118,10 +92,39 @@ describe('Settings view', function () {
 		});
 
 		view.load().then(function () {
-			view.$el.find('#u2f-enabled').prop('checked', true);
 			expect(view._getServerState).toHaveBeenCalled();
-			return view._onToggleEnabled().then(function () {
+			return view._onAddU2FDevice().then(function () {
 				expect(view._registerU2fDevice).toHaveBeenCalled();
+				expect(OC.Notification.showTemporary).not.toHaveBeenCalled();
+				done();
+			});
+		}).catch(function (e) {
+			done.fail(e);
+		});
+	});
+
+	it('lets the user remove a device', function (done) {
+		spyOn(OC.Notification, 'showTemporary');
+		spyOn(view, '_getServerState').and.returnValue(Promise.resolve({
+			devices: [
+				{
+					id: 13,
+					name: 'Yolokey'
+				}
+			]
+		}));
+		spyOn(view, '_requirePasswordConfirmation').and.returnValue(Promise.resolve());
+		jasmine.Ajax.stubRequest('/apps/twofactor_u2f/settings/remove').andReturn({
+			contentType: 'application/json',
+			responseText: JSON.stringify({})
+		});
+
+		view.load().then(function () {
+			expect(view._getServerState).toHaveBeenCalled();
+			var fakeEvent = {
+				target: view.$('.remove-device')
+			};
+			return view._onRemoveDevice(fakeEvent).then(function () {
 				expect(OC.Notification.showTemporary).not.toHaveBeenCalled();
 				done();
 			});

--- a/js/tests/test-main.js
+++ b/js/tests/test-main.js
@@ -1,10 +1,11 @@
 
-(function (global) {
+(function (global, Backbone) {
 	// Global variable stubs
 	global.OC = {};
 	global.OC.generateUrl = function (url) {
 		return url;
 	};
+	global.OC.Backbone = Backbone;
 	global.OC.Notification = {};
 	global.OC.Notification.showTemporary = function (txt) {
 		console.error('temporary notification', txt)
@@ -19,4 +20,4 @@
 		}
 		return txt;
 	};
-})(window);
+})(window, Backbone);

--- a/js/tests/test-main.js
+++ b/js/tests/test-main.js
@@ -6,7 +6,10 @@
 		return url;
 	};
 	global.OC.Notification = {};
-	global.OC.Notification.showTemporary = function () {
+	global.OC.Notification.showTemporary = function (txt) {
+		console.error('temporary notification', txt)
+	};
+	global.OC.registerMenu = function () {
 
 	};
 	global.OCA = {};

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -16,6 +16,7 @@ require_once(__DIR__ . '/../../vendor/yubico/u2flib-server/src/u2flib_server/U2F
 
 use OCA\TwoFactorU2F\Service\U2FManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
 
@@ -41,25 +42,19 @@ class SettingsController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @return JSONResponse
 	 */
 	public function state() {
 		return [
-			'enabled' => $this->manager->isEnabled($this->userSession->getUser())
+			'devices' => $this->manager->getDevices($this->userSession->getUser())
 		];
 	}
 
 	/**
 	 * @NoAdminRequired
 	 * @PasswordConfirmationRequired
-	 */
-	public function disable() {
-		$this->manager->disableU2F($this->userSession->getUser());
-	}
-
-	/**
-	 * @NoAdminRequired
-	 * @PasswordConfirmationRequired
 	 * @UseSession
+	 * @return JSONResponse
 	 */
 	public function startRegister() {
 		return $this->manager->startRegistration($this->userSession->getUser());
@@ -71,9 +66,22 @@ class SettingsController extends Controller {
 	 *
 	 * @param string $registrationData
 	 * @param string $clientData
+	 * @param string|null $name device name, given by user
+	 * @return JSONResponse
 	 */
-	public function finishRegister($registrationData, $clientData) {
-		$this->manager->finishRegistration($this->userSession->getUser(), $registrationData, $clientData);
+	public function finishRegister($registrationData, $clientData, $name = null) {
+		return $this->manager->finishRegistration($this->userSession->getUser(), $registrationData, $clientData, $name);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @PasswordConfirmationRequired
+	 *
+	 * @param int $id
+	 * @return JSONResponse
+	 */
+	public function remove($id) {
+		return $this->manager->removeDevice($this->userSession->getUser(), $id);
 	}
 
 }

--- a/lib/Db/Registration.php
+++ b/lib/Db/Registration.php
@@ -26,6 +26,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setCertificate(string $Certificate)
  * @method int getCounter()
  * @method void setCounter(int $counter)
+ * @method string getName()
+ * @method void setName(string $name)
  */
 class Registration extends Entity implements JsonSerializable {
 
@@ -34,6 +36,7 @@ class Registration extends Entity implements JsonSerializable {
 	protected $publicKey;
 	protected $certificate;
 	protected $counter;
+	protected $name;
 
 	public function jsonSerialize() {
 		return [
@@ -43,6 +46,7 @@ class Registration extends Entity implements JsonSerializable {
 			'publicKey' => $this->getPublicKey(),
 			'certificate' => $this->getCertificate(),
 			'counter' => $this->getCounter(),
+			'name' => $this->getName(),
 		];
 	}
 

--- a/lib/Db/RegistrationMapper.php
+++ b/lib/Db/RegistrationMapper.php
@@ -32,7 +32,7 @@ class RegistrationMapper extends Mapper {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 
-		$qb->select('id', 'user_id', 'key_handle', 'public_key', 'certificate', 'counter')
+		$qb->select('id', 'user_id', 'key_handle', 'public_key', 'certificate', 'counter', 'name')
 			->from('twofactor_u2f_registrations')
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($user->getUID())))
 			->andWhere($qb->expr()->eq('id', $qb->createNamedParameter($id)));
@@ -52,7 +52,7 @@ class RegistrationMapper extends Mapper {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 
-		$qb->select('id', 'user_id', 'key_handle', 'public_key', 'certificate', 'counter')
+		$qb->select('id', 'user_id', 'key_handle', 'public_key', 'certificate', 'counter', 'name')
 			->from('twofactor_u2f_registrations')
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($user->getUID())));
 		$result = $qb->execute();

--- a/lib/Provider/U2FProvider.php
+++ b/lib/Provider/U2FProvider.php
@@ -93,7 +93,7 @@ class U2FProvider implements IProvider {
 	 * @return boolean
 	 */
 	public function isTwoFactorAuthEnabledForUser(IUser $user) {
-		return $this->manager->isEnabled($user);
+		return count($this->manager->getDevices($user)) > 0;
 	}
 
 }

--- a/lib/Service/U2FManager.php
+++ b/lib/Service/U2FManager.php
@@ -70,19 +70,34 @@ class U2FManager {
 		return $registrationObjects;
 	}
 
-	public function isEnabled(IUser $user) {
+	/**
+	 * @param IUser $user
+	 * @return array
+	 */
+	public function getDevices(IUser $user) {
 		$registrations = $this->mapper->findRegistrations($user);
-		return count($registrations) > 0;
+		return array_map(function(Registration $reg) {
+			return [
+				'id' => $reg->getId(),
+				'name' => $reg->getName(),
+			];
+		}, $registrations);
 	}
 
-	public function disableU2F(IUser $user) {
-		// TODO: use single query instead
-		foreach ($this->mapper->findRegistrations($user) as $registration) {
-			$this->mapper->delete($registration);
-			$this->publishEvent($user, 'u2f_device_removed');
-		}
+	/**
+	 * @param IUser $user
+	 * @param int $id device id
+	 */
+	public function removeDevice(IUser $user, $id) {
+		$reg = $this->mapper->findRegistration($user, $id);
+		$this->mapper->delete($reg);
+		$this->publishEvent($user, 'u2f_device_removed');
 	}
 
+	/**
+	 * @param IUser $user
+	 * @return array
+	 */
 	public function startRegistration(IUser $user) {
 		$u2f = $this->getU2f();
 		$data = $u2f->getRegisterData($this->getRegistrations($user));
@@ -99,7 +114,13 @@ class U2FManager {
 		];
 	}
 
-	public function finishRegistration(IUser $user, $registrationData, $clientData) {
+	/**
+	 * @param IUser $user
+	 * @param string $registrationData
+	 * @param string $clientData
+	 * @param string $name
+	 */
+	public function finishRegistration(IUser $user, $registrationData, $clientData, $name = null) {
 		$this->logger->debug($registrationData);
 		$this->logger->debug($clientData);
 
@@ -117,10 +138,16 @@ class U2FManager {
 		$registration->setPublicKey($reg->publicKey);
 		$registration->setCertificate($reg->certificate);
 		$registration->setCounter($reg->counter);
+		$registration->setName($name);
 		$this->mapper->insert($registration);
 		$this->publishEvent($user, 'u2f_device_added');
 
 		$this->logger->debug(json_encode($reg));
+
+		return [
+			'id' => $registration->getId(),
+			'name' => $registration->getName(),
+		];
 	}
 
 	/**

--- a/templates/personal.php
+++ b/templates/personal.php
@@ -7,7 +7,10 @@ style('twofactor_u2f', 'style');
 
 <div class="section">
 	<h2><?php p($l->t('U2F second-factor auth')); ?></h2>
-	<div id="twofactor-u2f-settings"></div>
+	<div id="twofactor-u2f-settings">
+		<span class="icon-loading-small u2f-loading"></span>
+		<span><?php p($l->t('Loading your devices …')); ?></span>
+	</div>
 	<p class="utf-register-info" style="display: none;"><?php p($l->t('Please plug in your U2F device and press the device button to authorize.')) ?></p>
 	<p class="utf-register-info" style="display: none;"><em><?php p($l->t('Chrome is the only browser that supports U2F devices. You need to install the "U2F Support Add-on" on Firefox to use U2F.')) ?></em></p>
 	<p class="utf-register-success" style="display: none;"><span class="icon-checkmark-color" style="width: 16px;"></span><?php p($l->t('U2F device successfully registered.')) ?></p>

--- a/tests/unit/Activity/ProviderTest.php
+++ b/tests/unit/Activity/ProviderTest.php
@@ -29,9 +29,9 @@ use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
-use Test\TestCase;
+use PHPUnit_Framework_TestCase;
 
-class ProviderTest extends TestCase {
+class ProviderTest extends PHPUnit_Framework_TestCase {
 
 	private $l10n;
 	private $urlGenerator;

--- a/tests/unit/Activity/SettingTest.php
+++ b/tests/unit/Activity/SettingTest.php
@@ -24,9 +24,9 @@ namespace OCA\TwoFactorU2F\Tests\Unit\Activity;
 
 use OCA\TwoFactorU2F\Activity\Setting;
 use OCP\IL10N;
-use Test\TestCase;
+use PHPUnit_Framework_TestCase;
 
-class SettingTest extends TestCase {
+class SettingTest extends PHPUnit_Framework_TestCase {
 
 	private $l10n;
 

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -18,9 +18,9 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit_Framework_MockObject_MockObject;
-use Test\TestCase;
+use PHPUnit_Framework_TestCase;
 
-class SettingsControllerTest extends TestCase {
+class SettingsControllerTest extends PHPUnit_Framework_TestCase {
 
 	/** @var IRequest|PHPUnit_Framework_MockObject_MockObject */
 	private $request;
@@ -46,30 +46,28 @@ class SettingsControllerTest extends TestCase {
 
 	public function testState() {
 		$user = $this->createMock(IUser::class);
+		$devices = [
+			[
+				'id' => 1,
+				'name' => null,
+			],
+			[
+				'id' => 2,
+				'name' => 'Yolokey',
+			],
+		];
 		$this->userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
 		$this->u2fManager->expects($this->once())
-			->method('isEnabled')
+			->method('getDevices')
 			->with($this->equalTo($user))
-			->willReturn(true);
+			->willReturn($devices);
 
 		$expected = [
-		    'enabled' => true,
+			'devices' => $devices,
 		];
 		$this->assertSame($expected, $this->controller->state());
-	}
-
-	public function testDisable() {
-		$user = $this->createMock(IUser::class);
-		$this->userSession->expects($this->once())
-			->method('getUser')
-			->willReturn($user);
-		$this->u2fManager->expects($this->once())
-			->method('disableU2F')
-			->with($this->equalTo($user));
-
-		$this->controller->disable();
 	}
 
 	public function testStartRegister() {

--- a/tests/unit/Provider/U2FProviderTest.php
+++ b/tests/unit/Provider/U2FProviderTest.php
@@ -18,9 +18,9 @@ use OCP\IL10N;
 use OCP\IUser;
 use OCP\Template;
 use PHPUnit_Framework_MockObject_MockObject;
-use Test\TestCase;
+use PHPUnit_Framework_TestCase;
 
-class U2FProviderTest extends TestCase {
+class U2FProviderTest extends PHPUnit_Framework_TestCase {
 
 	/** @var IL10N|PHPUnit_Framework_MockObject_MockObject */
 	private $l10n;
@@ -84,10 +84,24 @@ class U2FProviderTest extends TestCase {
 
 	public function testIsTwoFactorAuthEnabledForUser() {
 		$user = $this->createMock(IUser::class);
+		$devices = [
+			'dev1',
+		];
 
 		$this->manager->expects($this->once())
-			->method('isEnabled')
-			->willReturn(false);
+			->method('getDevices')
+			->willReturn($devices);
+
+		$this->assertTrue($this->provider->isTwoFactorAuthEnabledForUser($user));
+	}
+
+	public function testIsTwoFactorAuthDisabledForUser() {
+		$user = $this->createMock(IUser::class);
+		$devices = [];
+
+		$this->manager->expects($this->once())
+			->method('getDevices')
+			->willReturn($devices);
 
 		$this->assertFalse($this->provider->isTwoFactorAuthEnabledForUser($user));
 	}


### PR DESCRIPTION
Users should be able to add as many devices as they like, hence
the interface should allow to list added devices and have a button
to add new ones. To identify devices later, users can give names
to devices.

## TODO
- [x] Generic name if none assigned (e.g. due to migration from older version)
- [x] Ability to unregister a key
- [x] Fix and add tests

---
## Screenshot
![bildschirmfoto von 2017-03-14 15-10-56](https://cloud.githubusercontent.com/assets/1374172/23904666/f7b472cc-08c8-11e7-9c24-4d6f8004e234.png)

---

Fixes https://github.com/nextcloud/twofactor_u2f/issues/15