### PR TITLE
Fix Backbone namespacing

### DIFF
--- a/js/settingsview.js
+++ b/js/settingsview.js
@@ -242,4 +242,4 @@
 
 	OCA.TwoFactorU2F.SettingsView = SettingsView;
 
-})(OC, OCA, Backbone, Handlebars, $, u2f);
+})(OC, OCA, OC.Backbone, Handlebars, $, u2f);


### PR DESCRIPTION
Caused by nextcloud/server#3994

Before: No settings present
After: Settings present