### PR TITLE
Fix failed u2f login attempts due to missing requests in sign request

### DIFF
--- a/js/challenge.js
+++ b/js/challenge.js
@@ -36,12 +36,8 @@
 		var req = JSON.parse($('#u2f-auth').val());
 
 		toggleError(false);
-		var pathArray = location.href.split('/');
-		var protocol = pathArray[0];
-		var host = pathArray[2];
-		var url = protocol + '//' + host;
 		console.log("sign: ", req);
-		u2f.sign(url, req[0].challenge, req, signCallback);
+		u2f.sign(req, signCallback);
 	}
 
 	$(sign);


### PR DESCRIPTION
When using multiple u2f tokens, we have to pass all signing requests/challenges
to the u2f library, otherwise the sign request might fail depending
on which device we use (it will work with the very first one).

@LukasReschke as discussed. Would be great to have another person test this critical bugfix. It works on my local instance with both devices. Without the fix, I can only authenticate with one of them.

U2F API usage was inspired by https://github.com/Yubico/php-u2flib-server/blob/25863d132500f7da0d6e89ca0d1805b6c81c6267/examples/localstorage/index.phps#L123