### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 1.5.0 – 2017-11-27
+## 1.5.0 – 2017-12-13
 ### Added
 - Show warning if HTTP is used
+- Php7.2 support
+- Nextcloud 13 support
+- New translations
+- Firefox' internal U2F
+### Fixed
+- Settings are now listed in security section
 
 ## 1.4.0 – 2017-10-30
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,59 +1,13 @@
 # Makefile for building the project
 
-app_name=twofactor_u2f
-project_dir=$(CURDIR)/../$(app_name)
-build_dir=$(CURDIR)/build/artifacts
-sign_dir=$(build_dir)/sign
-appstore_dir=$(build_dir)/appstore
-source_dir=$(build_dir)/source
-package_name=$(app_name)
-cert_dir=$(HOME)/.nextcloud/certificates
-
-all: install-deps
+all: install
 
 clean:
 	rm -rf vendor
+	rm -rf node_modules
+	rm -rf js/build
 
-composer.phar:
-	curl -sS https://getcomposer.org/installer | php
-
-update-composer: composer.phar
-	rm -f composer.lock
-	php composer.phar install --prefer-dist
-
-appstore:
-	mkdir -p $(sign_dir)
-	composer install --no-dev
-	rsync -a \
-	--delete \
-	--exclude=.git \
-	--exclude=build \
-	--exclude=.gitignore \
-	--exclude=.travis.yml \
-	--exclude=.scrutinizer.yml \
-	--exclude=CONTRIBUTING.md \
-	--exclude=composer.json \
-	--exclude=composer.lock \
-	--exclude=composer.phar \
-	--exclude=coverage \
-	--exclude=karma.conf.js \
-	--exclude=l10n/.tx \
-	--exclude=l10n/no-php \
-	--exclude=Makefile \
-	--exclude=nbproject \
-	--exclude=node_modules \
-	--exclude=package.json \
-	--exclude=screenshots \
-	--exclude=phpunit*xml \
-	--exclude=tests \
-	--exclude=vendor/bin \
-	--exclude=vendor/yubico/u2flib-server/examples \
-	$(project_dir) $(sign_dir)
-	@echo "Signing…"
-	php ../../occ integrity:sign-app \
-		--privateKey=$(cert_dir)/$(app_name).key\
-		--certificate=$(cert_dir)/$(app_name).crt\
-		--path=$(sign_dir)/$(app_name)
-	tar -czf $(build_dir)/$(app_name).tar.gz \
-		-C $(sign_dir) $(app_name)
-	openssl dgst -sha512 -sign $(cert_dir)/$(app_name).key $(build_dir)/$(app_name).tar.gz | openssl base64
+install:
+	composer install --dev
+	npm install
+	npm run build

--- a/krankerl.toml
+++ b/krankerl.toml
@@ -1,0 +1,33 @@
+[package]
+exclude = [
+	"AUTHORS.md",
+	"build",
+	".git",
+	".gitignore",
+	".travis.yml",
+	".scrutinizer.yml",
+        "CONTRIBUTING.md",
+	"composer.json",
+	"composer.lock",
+	"composer.phar",
+	"js/tests",
+	"js/*.js",
+	"karma.conf.js",
+	"krankerl.toml",
+	"l10n/.tx",
+	"l10n/no-php",
+	"Makefile",
+	"nbproject",
+	"node_modules",
+	"package.json",
+	"package-lock.json",
+	"screenshots",
+	"tests",
+	"vendor/bin",
+]
+
+before_cmds = [
+	"composer install --no-dev -o",
+	"npm install",
+	"npm run build",
+]


### PR DESCRIPTION
* Fix legacy Makefile
* Switch to Krankerl packaging

- [x] Requires #76 
- [x] Update changelog

Test build: 
[twofactor_u2f.tar.gz](https://github.com/nextcloud/twofactor_u2f/files/1555908/twofactor_u2f.tar.gz)

