### PR TITLE
Release 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.5.3 – 2018-04-30
+### Fixed
+- Allow Nextcloud 13.0.2
+
 ## 1.5.2 – 2018-03-28
 ### Changed
 - Requires Nextcloud 13.0.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Two Factor U2F</name>
 	<summary>U2F two-factor provider</summary>
 	<description>A two-factor provider for U2F devices</description>
-	<version>1.5.2</version>
+	<version>1.5.3</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorU2F</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,7 +349,7 @@
       "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
       "dev": true,
       "requires": {
-        "underscore": "1.8.3"
+        "underscore": "1.9.0"
       }
     },
     "backo2": {


### PR DESCRIPTION
- [x] Bump version number
- [x] Build beta release: [twofactor_u2f.tar.gz](https://github.com/nextcloud/twofactor_u2f/files/1959955/twofactor_u2f.tar.gz)
- [ ] Publish on apps.nextcloud.com
- [ ] Forward-port changelog to master

Fixes https://github.com/nextcloud/twofactor_u2f/issues/152