### PR TITLE
Fix provider state population to the server registry

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Nextcloud - U2F 2FA
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2018
+ */
+
+namespace OCA\TwoFactorU2F\AppInfo;
+
+use OCA\TwoFactorU2F\Event\StateChanged;
+use OCA\TwoFactorU2F\Listener\IListener;
+use OCA\TwoFactorU2F\Listener\StateChangeActivity;
+use OCP\AppFramework\App;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class Application extends App {
+
+	public function __construct(array $urlParams = []) {
+		parent::__construct('twofactor_u2f', $urlParams);
+
+		$container = $this->getContainer();
+		/** @var EventDispatcherInterface $eventDispatcher */
+		$eventDispatcher = $container->getServer()->getEventDispatcher();
+		$eventDispatcher->addListener(StateChanged::class, function (StateChanged $event) use ($container) {
+			/** @var IListener[] $listeners */
+			$listeners = [
+				$container->query(StateChangeActivity::class),
+			];
+
+			foreach ($listeners as $listener) {
+				$listener->handle($event);
+			}
+		});
+	}
+
+}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -17,6 +17,7 @@ namespace OCA\TwoFactorU2F\AppInfo;
 use OCA\TwoFactorU2F\Event\StateChanged;
 use OCA\TwoFactorU2F\Listener\IListener;
 use OCA\TwoFactorU2F\Listener\StateChangeActivity;
+use OCA\TwoFactorU2F\Listener\StateChangeRegistryUpdater;
 use OCP\AppFramework\App;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -32,6 +33,7 @@ class Application extends App {
 			/** @var IListener[] $listeners */
 			$listeners = [
 				$container->query(StateChangeActivity::class),
+				$container->query(StateChangeRegistryUpdater::class),
 			];
 
 			foreach ($listeners as $listener) {

--- a/lib/Event/StateChanged.php
+++ b/lib/Event/StateChanged.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Nextcloud - U2F 2FA
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2018
+ */
+
+namespace OCA\TwoFactorU2F\Event;
+
+use OCP\IUser;
+use Symfony\Component\EventDispatcher\Event;
+
+class StateChanged extends Event {
+
+	/** @var IUser */
+	private $user;
+
+	/** @var bool */
+	private $enabled;
+
+	public function __construct(IUser $user, bool $enabled) {
+		$this->user = $user;
+		$this->enabled = $enabled;
+	}
+
+	/**
+	 * @return IUser
+	 */
+	public function getUser(): IUser {
+		return $this->user;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isEnabled(): bool {
+		return $this->enabled;
+	}
+
+}

--- a/lib/Listener/IListener.php
+++ b/lib/Listener/IListener.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Nextcloud - U2F 2FA
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2018
+ */
+
+namespace OCA\TwoFactorU2F\Listener;
+
+use Symfony\Component\EventDispatcher\Event;
+
+interface IListener {
+
+	public function handle(Event $event);
+
+}

--- a/lib/Listener/StateChangeActivity.php
+++ b/lib/Listener/StateChangeActivity.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Nextcloud - U2F 2FA
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2018
+ */
+
+namespace OCA\TwoFactorU2F\Listener;
+
+use OCA\TwoFactorU2F\Event\StateChanged;
+use OCP\Activity\IManager;
+use Symfony\Component\EventDispatcher\Event;
+
+class StateChangeActivity implements IListener {
+
+	/** @var IManager */
+	private $activityManager;
+
+	public function __construct(IManager $activityManager) {
+		$this->activityManager = $activityManager;
+	}
+
+	public function handle(Event $event) {
+		if ($event instanceof StateChanged) {
+			$subject = $event->isEnabled() ? 'u2f_device_added' : 'u2f_device_removed';
+
+			$activity = $this->activityManager->generateEvent();
+			$activity->setApp('twofactor_u2f')
+				->setType('security')
+				->setAuthor($event->getUser()->getUID())
+				->setAffectedUser($event->getUser()->getUID())
+				->setSubject($subject);
+			$this->activityManager->publish($activity);
+		}
+	}
+}

--- a/lib/Listener/StateChangeRegistryUpdater.php
+++ b/lib/Listener/StateChangeRegistryUpdater.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Nextcloud - U2F 2FA
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2018
+ */
+
+namespace OCA\TwoFactorU2F\Listener;
+
+use OCA\TwoFactorU2F\Event\StateChanged;
+use OCA\TwoFactorU2F\Provider\U2FProvider;
+use OCP\Authentication\TwoFactorAuth\IRegistry;
+use Symfony\Component\EventDispatcher\Event;
+
+class StateChangeRegistryUpdater implements IListener {
+
+	/** @var IRegistry */
+	private $providerRegistry;
+
+	/** @var U2FProvider */
+	private $provider;
+
+	public function __construct(IRegistry $providerRegistry, U2FProvider $provider) {
+		$this->providerRegistry = $providerRegistry;
+		$this->provider = $provider;
+	}
+
+	public function handle(Event $event) {
+		if ($event instanceof StateChanged) {
+			if ($event->isEnabled()) {
+				$this->providerRegistry->enableProviderFor($this->provider, $event->getUser());
+			} else {
+				$this->providerRegistry->disableProviderFor($this->provider, $event->getUser());
+			}
+		}
+	}
+}

--- a/tests/Unit/Event/StateChangedTest.php
+++ b/tests/Unit/Event/StateChangedTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Nextcloud - U2F 2FA
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2018
+ */
+
+namespace OCA\TwoFactorU2F\Tests\Unit\Event;
+
+use OCA\TwoFactorU2F\Event\StateChanged;
+use OCP\IUser;
+use PHPUnit\Framework\TestCase;
+
+class StateChangedTest extends TestCase {
+
+	public function testEnabledState() {
+		$user = $this->createMock(IUser::class);
+
+		$event = new StateChanged($user, true);
+
+		$this->assertTrue($event->isEnabled());
+		$this->assertSame($user, $event->getUser());
+	}
+
+	public function testDisabledState() {
+		$user = $this->createMock(IUser::class);
+
+		$event = new StateChanged($user, false);
+
+		$this->assertFalse($event->isEnabled());
+		$this->assertSame($user, $event->getUser());
+	}
+
+}

--- a/tests/Unit/Listener/StateChangeRegistryUpdaterTest.php
+++ b/tests/Unit/Listener/StateChangeRegistryUpdaterTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: christoph
+ * Date: 31.07.18
+ * Time: 08:11
+ */
+
+namespace OCA\TwoFactorU2F\Tests\Unit\Listener;
+
+use OCA\TwoFactorU2F\Event\StateChanged;
+use OCA\TwoFactorU2F\Listener\StateChangeRegistryUpdater;
+use OCA\TwoFactorU2F\Provider\U2FProvider;
+use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\IUser;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+use Symfony\Component\EventDispatcher\Event;
+
+class StateChangeRegistryUpdaterTest extends TestCase {
+
+	/** @var IRegistry|PHPUnit_Framework_MockObject_MockObject */
+	private $providerRegistry;
+
+	/** @var U2FProvider|PHPUnit_Framework_MockObject_MockObjec */
+	private $provider;
+
+	/** @var StateChangeRegistryUpdater */
+	private $listener;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->providerRegistry = $this->createMock(IRegistry::class);
+		$this->provider = $this->createMock(U2FProvider::class);
+
+		$this->listener = new StateChangeRegistryUpdater($this->providerRegistry, $this->provider);
+	}
+
+	public function testHandleGenericEvent() {
+		$event = $this->createMock(Event::class);
+		$this->providerRegistry->expects($this->never())
+			->method('enableProviderFor');
+		$this->providerRegistry->expects($this->never())
+			->method('disableProviderFor');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleEnableEvent() {
+		$user = $this->createMock(IUser::class);
+		$event = new StateChanged($user, true);
+		$this->providerRegistry->expects($this->once())
+			->method('enableProviderFor')
+			->with(
+				$this->provider,
+				$user
+			);
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleDisableEvent() {
+		$user = $this->createMock(IUser::class);
+		$event = new StateChanged($user, false);
+		$this->providerRegistry->expects($this->once())
+			->method('disableProviderFor')
+			->with(
+				$this->provider,
+				$user
+			);
+
+		$this->listener->handle($event);
+	}
+}


### PR DESCRIPTION
Required for https://github.com/orgs/nextcloud/projects/4#card-10826964

This PR consists of two parts. First, a little refactoring to decouple some logic from the provider to decouple it from the necessary action on enabled/disabled state change via the server event system. Second, it adds a new state change listener that populates the state to the server's provider registry.

This is a 1:1 port of https://github.com/nextcloud/twofactor_totp/pull/263 for this app.

- [x] Requires https://github.com/nextcloud/server/pull/10462