### PR TITLE
Fix authentication/login registration id missing property

### DIFF
--- a/lib/Service/U2FManager.php
+++ b/lib/Service/U2FManager.php
@@ -154,7 +154,10 @@ class U2FManager {
 			return false;
 		}
 
-		$registration = $this->mapper->findRegistration($user, $reg->id);
+		$origReg = reset(array_filter($registrations, function(object $registration) use ($reg) {
+			return $registration->keyHandle === $reg->keyHandle;
+		}));
+		$registration = $this->mapper->findRegistration($user, $origReg->id);
 		$registration->setCounter($reg->counter);
 		$this->mapper->update($registration);
 		return true;


### PR DESCRIPTION
As of https://github.com/Yubico/php-u2flib-server/commit/af674fec3f077c3f447e51696656c6b8ea3b293e, the passed
registrations array is stripped and only u2f properties are returned. Hence, the `id` prop gets removed and
we have to look it up in the original data instead.

Regression of #233.