### PR TITLE
Applying the Logspam fix from twofactor_totp

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -28,9 +28,6 @@
 		<provider>OCA\TwoFactorU2F\Provider\U2FProvider</provider>
 	</two-factor-providers>
 
-	<settings>
-		<personal>OCA\TwoFactorU2F\Settings\Personal</personal>
-	</settings>
 	<activity>
 		<settings>
 			<setting>OCA\TwoFactorU2F\Activity\Setting</setting>


### PR DESCRIPTION
I've applied the changes from https://github.com/nextcloud/twofactor_totp/pull/372 also to twofactor_u2f and it stopped the logspam as described here:
https://help.nextcloud.com/t/could-not-resolve-devices-class-devices-does-not-exist-post-nextcloud-upgrade-from-14-15/45990

See also https://github.com/nextcloud/twofactor_totp/issues/368