### PR TITLE
Fix sorting devices without a name

### DIFF
--- a/src/main-settings.js
+++ b/src/main-settings.js
@@ -29,7 +29,16 @@ Vue.mixin(Nextcloud)
 const initialStateElement = document.getElementById('twofactor-u2f-initial-state')
 if (initialStateElement) {
 	const devices = JSON.parse(initialStateElement.value)
-	devices.sort((d1, d2) => d1.name.localeCompare(d2.name))
+	devices.sort()
+	devices.sort((d1, d2) => {
+		if (!d1.name) {
+			return 1
+		} else if (!d2.name) {
+			return -1
+		} else {
+			return d1.name.localeCompare(d2.name)
+		}
+	})
 	store.replaceState({
 		devices
 	})


### PR DESCRIPTION
Fixes https://github.com/nextcloud/twofactor_u2f/issues/352

Tested with setting one device's name to `null` in the db.

![Bildschirmfoto von 2019-03-27 20-25-41](https://user-images.githubusercontent.com/1374172/55106150-84064800-50ce-11e9-8ef6-12af7962d409.png)
