### PR TITLE
Do not import all of the vue-components

### DIFF
--- a/src/components/Device.vue
+++ b/src/components/Device.vue
@@ -38,7 +38,7 @@
 <script>
 	import ClickOutside from 'vue-click-outside'
 	import confirmPassword from '@nextcloud/password-confirmation'
-	import {PopoverMenu} from 'nextcloud-vue'
+	import { PopoverMenu } from 'nextcloud-vue/dist/Components/PopoverMenu'
 
 	export default {
 		name: 'Device',


### PR DESCRIPTION
We only use the PopoverMenu. Saves a whole lot of bundled JS

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>