### PR TITLE
Update README to reflect current Firefox status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
 In order to use this app for authentication, you have to use a browser that supports the U2F standard:
 * Google Chrome
 * Chromium
-* Firefox 
+* Firefox
+  * V67 or newer
+  * V57 to V66: After activation of `security.webauth.u2f` in `about:config`
   * V56 or before: In combination with [this extension](https://addons.mozilla.org/en-US/firefox/addon/u2f-support-add-on/)
-  * V57 or newer: After activation of `security.webauth.u2f` in `about:config`
 * Opera
 
 ## Login with external apps


### PR DESCRIPTION
Closes #69 

U2F is on by default starting in V67: https://support.yubico.com/support/solutions/articles/15000017511-enabling-u2f-support-in-mozilla-firefox