### PR TITLE
Fix U2F reverse proxy bug

### DIFF
--- a/lib/Service/U2FManager.php
+++ b/lib/Service/U2FManager.php
@@ -59,7 +59,7 @@ class U2FManager {
 	}
 
 	private function getU2f(): U2F {
-		$url = $this->request->getServerProtocol() . '://' . $this->request->getServerHost();
+		$url = $this->request->getHttpProtocol() . '://' . $this->request->getServerHost();
 		return new U2F($url);
 	}
 


### PR DESCRIPTION
Fix getU2F function to use the correct protocol when a reverse proxy is in use.  This is based on issue #916 